### PR TITLE
Implement content restriction for non-logged-in users

### DIFF
--- a/custrest/admin/meta-box.php
+++ b/custrest/admin/meta-box.php
@@ -1,0 +1,2 @@
+<?php
+// Admin meta box for custrest plugin

--- a/custrest/admin/settings.php
+++ b/custrest/admin/settings.php
@@ -1,0 +1,92 @@
+<?php
+// Admin settings for custrest plugin
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_action( 'admin_menu', 'custrest_admin_menu' );
+add_action( 'admin_init', 'custrest_register_settings' );
+
+function custrest_admin_menu() {
+    add_options_page(
+        __( 'Restrict Access Settings', 'custrest' ),
+        __( 'Restrict Access', 'custrest' ),
+        'manage_options',
+        'custrest-settings',
+        'custrest_settings_page'
+    );
+}
+
+function custrest_register_settings() {
+    register_setting( 'custrest_settings_group', CUSTREST_OPTION_KEY, 'custrest_sanitize_settings' );
+
+    add_settings_section(
+        'custrest_main_section',
+        __( 'Restriction Settings', 'custrest' ),
+        '__return_false',
+        'custrest-settings'
+    );
+
+    add_settings_field(
+        'custrest_post_types',
+        __( 'Post Types to Restrict', 'custrest' ),
+        'custrest_post_types_field',
+        'custrest-settings',
+        'custrest_main_section'
+    );
+
+    add_settings_field(
+        'custrest_redirect_url',
+        __( 'Redirect URL if not logged in', 'custrest' ),
+        'custrest_redirect_url_field',
+        'custrest-settings',
+        'custrest_main_section'
+    );
+}
+
+function custrest_post_types_field() {
+    $options = get_option( CUSTREST_OPTION_KEY );
+    $selected = isset( $options['post_types'] ) ? (array) $options['post_types'] : array();
+    $post_types = get_post_types( array( 'public' => true ), 'objects' );
+    foreach ( $post_types as $pt ) {
+        printf(
+            '<label><input type="checkbox" name="%s[post_types][]" value="%s" %s> %s</label><br>',
+            esc_attr( CUSTREST_OPTION_KEY ),
+            esc_attr( $pt->name ),
+            checked( in_array( $pt->name, $selected ), true, false ),
+            esc_html( $pt->labels->singular_name )
+        );
+    }
+}
+
+function custrest_redirect_url_field() {
+    $options = get_option( CUSTREST_OPTION_KEY );
+    $url = isset( $options['redirect_url'] ) ? esc_url( $options['redirect_url'] ) : '';
+    printf(
+        '<input type="url" name="%s[redirect_url]" value="%s" class="regular-text" placeholder="%s" />',
+        esc_attr( CUSTREST_OPTION_KEY ),
+        $url,
+        esc_attr( home_url( '/wp-login.php' ) )
+    );
+}
+
+function custrest_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php _e( 'Restrict Access Settings', 'custrest' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields( 'custrest_settings_group' );
+            do_settings_sections( 'custrest-settings' );
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}
+
+function custrest_sanitize_settings( $input ) {
+    $output = array();
+    $output['post_types'] = isset( $input['post_types'] ) ? array_map( 'sanitize_text_field', (array) $input['post_types'] ) : array();
+    $output['redirect_url'] = isset( $input['redirect_url'] ) ? esc_url_raw( $input['redirect_url'] ) : '';
+    return $output;
+}

--- a/custrest/custrest.php
+++ b/custrest/custrest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+Plugin Name: Custom Page/Post Restriction (custrest)
+Description: Restrict access to selected post types/pages for non-logged-in users with global and per-post overrides.
+Version: 1.0.0
+Author: Your Name
+Text Domain: custrest
+Domain Path: /languages
+*/
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Plugin constants
+define( 'CUSTREST_VERSION', '1.0.0' );
+define( 'CUSTREST_DIR', plugin_dir_path( __FILE__ ) );
+define( 'CUSTREST_URL', plugin_dir_url( __FILE__ ) );
+
+define( 'CUSTREST_OPTION_KEY', 'custrest_settings' );
+
+define( 'CUSTREST_TEXT_DOMAIN', 'custrest' );
+
+// Load plugin files
+add_action( 'plugins_loaded', 'custrest_load_plugin' );
+function custrest_load_plugin() {
+    // Admin
+    if ( is_admin() ) {
+        require_once CUSTREST_DIR . 'admin/settings.php';
+        require_once CUSTREST_DIR . 'admin/meta-box.php';
+    }
+    // Frontend
+    require_once CUSTREST_DIR . 'includes/restriction.php';
+    require_once CUSTREST_DIR . 'includes/helpers.php';
+}

--- a/custrest/includes/helpers.php
+++ b/custrest/includes/helpers.php
@@ -1,0 +1,2 @@
+<?php
+// Helper functions for custrest plugin

--- a/custrest/includes/restriction.php
+++ b/custrest/includes/restriction.php
@@ -1,0 +1,2 @@
+<?php
+// Restriction logic for custrest plugin


### PR DESCRIPTION
Implements the initial plugin scaffold and global admin settings for post type restriction and redirect URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-43e37a1f-2e1d-4cd4-bb59-f81f7f34c04e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43e37a1f-2e1d-4cd4-bb59-f81f7f34c04e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

